### PR TITLE
maple: revert inverted logic of offhook HID value

### DIFF
--- a/csharp/sdk/Maple/Phone.cs
+++ b/csharp/sdk/Maple/Phone.cs
@@ -339,7 +339,7 @@ namespace Maple
                         break;
                     case HidUsage.Telephony.ActivateHandsetAudio:
                         Console.WriteLine("Sending offHook with: " + offHook);
-                        dataItem.WriteRaw(buf, bitOffset, 0, Convert.ToUInt32(!offHook));
+                        dataItem.WriteRaw(buf, bitOffset, 0, Convert.ToUInt32(offHook));
                         break;
                     default:
                         break;


### PR DESCRIPTION
e2e66e5 inverted the offhook signal's value, I don't know why, since
the FW looks like this:
if (outReport.offhook) {
  PhonyTakeOffHook();
} else {
  PhonyHangUp();
}

@lukebayes what's the reason for inverting the value?