### PR TITLE
Moved LoopState check above WaitForResponse in Dial method to prevent…

### DIFF
--- a/csharp/sdk/Maple/Phone.cs
+++ b/csharp/sdk/Maple/Phone.cs
@@ -286,14 +286,14 @@ namespace Maple
 
         public bool Dial(String input)
         {
-            // Ensure we're not already waiting for a response.
-            WaitForResponse();
-
             if (!LoopState)
             {
                 Console.WriteLine("Cannot Dial without a valid line detected.");
                 return false;
             }
+
+            // Ensure we're not already waiting for a response.
+            WaitForResponse();
 
             if (!OffHook)
             {


### PR DESCRIPTION
… infinite loop. The LoopState check will allow us to return out of the Dial call in the event there is not an active phone line.