### PR TITLE
Introduced hook to opt out of Audio Ducking

### DIFF
--- a/csharp/sdk/Maple/AudioStitcher.cs
+++ b/csharp/sdk/Maple/AudioStitcher.cs
@@ -52,21 +52,20 @@ namespace Maple
             StartWasapi();
         }
 
-        private void LogWaveFormat(String label, WaveFormat waveFormat)
-        {
-            Console.WriteLine(label + " ENC: " + waveFormat.Encoding + " SR: " + waveFormat.SampleRate + " CH: " + waveFormat.Channels);
-        }
-
         public void StartWasapi()
         {
             Console.WriteLine("----------------------------");
             Console.WriteLine("Wasapi AudioStitcher.Start()");
+
             // Get each of the 4 audio devices by name and data flow.
             FromPhoneLineDevice = GetMMDeviceByName(RxName, DataFlow.Capture);
             ToPhoneLineDevice = GetMMDeviceByName(TxName, DataFlow.Render);
 
             ToSpeakerDevice = new MMDeviceEnumerator().GetDefaultAudioEndpoint(DataFlow.Render, Role.Communications);
             FromMicDevice = new MMDeviceEnumerator().GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+
+            var duckingStatus = ToSpeakerDevice.AudioSessionManager.AudioSessionControl.SetDuckingPreference(true);
+            Console.WriteLine($"Audio Ducking opt-out return status (zero == success): {duckingStatus}");
 
             // Configure the Line to Speaker connection.
             FromPhoneLineChannel = new WasapiCapture(FromPhoneLineDevice, DEFAULT_SYNC, DEFAULT_LATENCY);

--- a/csharp/sdk/Maple/Maple.csproj
+++ b/csharp/sdk/Maple/Maple.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="1.10.0" />
+    <ProjectReference Include="..\..\..\..\NAudio\NAudio\NAudio.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Requires Vendored version of NAudio, which is currently hosted here:

https://github.com/lukebayes/NAudio/tree/lbj-autonome

This relative path, disk based linkage to NAudio is not ideal at all, but it unblocks AutononoME development and helps get the patients a much better audio and telephone experience.